### PR TITLE
Add .NET 10 Coupa Invoice Sync API with generic mapping pipeline

### DIFF
--- a/Coupa.InvoiceSync.sln
+++ b/Coupa.InvoiceSync.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Coupa.InvoiceSync.Api", "src\Coupa.InvoiceSync.Api\Coupa.InvoiceSync.Api.csproj", "{C95CCAFB-5A96-4E70-B90D-14E3518F31D8}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C95CCAFB-5A96-4E70-B90D-14E3518F31D8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C95CCAFB-5A96-4E70-B90D-14E3518F31D8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C95CCAFB-5A96-4E70-B90D-14E3518F31D8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C95CCAFB-5A96-4E70-B90D-14E3518F31D8}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,1 +1,58 @@
-smita parmar
+# Coupa Invoice Sync API (.NET 10 / C#)
+
+This repository now includes a production-style Web API solution to synchronize invoices from Coupa, map them generically, route by region/destination system, persist to target databases, and stage failures as raw JSON payloads.
+
+## Solution Structure
+
+- `src/Coupa.InvoiceSync.Api`
+  - `Controllers` – API endpoints.
+  - `Application/Abstractions` – SOLID interfaces for integration points.
+  - `Application/Services` – orchestration use case service.
+  - `Application/Pipeline` – middleware-like processing pipeline abstractions and implementation.
+  - `Domain/Entities` + `Domain/Enums` – business models.
+  - `Infrastructure/Coupa` – Coupa API client.
+  - `Infrastructure/Mapping` – generic field mapping middleware + validation middleware.
+  - `Infrastructure/Persistence` – region/target repositories, repository factory, staging error repository.
+  - `Infrastructure/Options` – typed config models.
+
+## API Endpoint
+
+- `POST /api/invoices/sync`
+  - Calls Coupa Get Invoices API.
+  - Maps source payload to canonical model with configurable middleware.
+  - Routes records to target repository by `region` + `destination_system`.
+  - Writes failed records to staging error table abstraction as raw JSON.
+  - Returns success summary.
+
+## Generic Mapping Middleware
+
+Field mappings are configured in `appsettings.json` under `Mapping:Profiles:CoupaToCanonical:FieldMappings`.
+
+Example:
+
+```json
+{ "SourceField": "supplier_name", "TargetField": "SupplierName" }
+```
+
+This enables easy source/target remapping without changing code.
+
+## Region + Third-Party Routing
+
+Routing is configured in `appsettings.json` under `Routing:RouteToRepository`.
+
+Example:
+
+```json
+"NA:MSDynamics": "MsDynamicsInvoiceRepository"
+```
+
+This allows easy onboarding of additional third-party invoice sinks.
+
+## Method/Class Summaries
+
+All related classes and methods contain XML summaries so generated docs and IDE tooltips clearly explain responsibilities and behavior.
+
+## Notes
+
+- Project targets `.NET 10` as requested (`net10.0`).
+- Repository implementations are in-memory placeholders to demonstrate clean architecture and extension points; replace with concrete SQL adapters in production.

--- a/src/Coupa.InvoiceSync.Api/Application/Abstractions/ICoupaInvoiceClient.cs
+++ b/src/Coupa.InvoiceSync.Api/Application/Abstractions/ICoupaInvoiceClient.cs
@@ -1,0 +1,16 @@
+using Coupa.InvoiceSync.Api.Domain.Entities;
+
+namespace Coupa.InvoiceSync.Api.Application.Abstractions;
+
+/// <summary>
+/// Provides access to Coupa invoice data.
+/// </summary>
+public interface ICoupaInvoiceClient
+{
+    /// <summary>
+    /// Calls Coupa's Get Invoices API and returns all discovered invoices.
+    /// </summary>
+    /// <param name="cancellationToken">A token that cancels the operation.</param>
+    /// <returns>A list of source invoices.</returns>
+    Task<IReadOnlyCollection<CoupaInvoice>> GetInvoicesAsync(CancellationToken cancellationToken);
+}

--- a/src/Coupa.InvoiceSync.Api/Application/Abstractions/IErrorStagingRepository.cs
+++ b/src/Coupa.InvoiceSync.Api/Application/Abstractions/IErrorStagingRepository.cs
@@ -1,0 +1,16 @@
+namespace Coupa.InvoiceSync.Api.Application.Abstractions;
+
+/// <summary>
+/// Stores failed invoice payloads in a staging error table.
+/// </summary>
+public interface IErrorStagingRepository
+{
+    /// <summary>
+    /// Saves raw payload and error details for later reprocessing.
+    /// </summary>
+    /// <param name="invoiceId">The invoice identifier.</param>
+    /// <param name="payload">The original JSON payload.</param>
+    /// <param name="error">The processing error message.</param>
+    /// <param name="cancellationToken">A token that cancels the operation.</param>
+    Task InsertErrorAsync(string invoiceId, string payload, string error, CancellationToken cancellationToken);
+}

--- a/src/Coupa.InvoiceSync.Api/Application/Abstractions/IInvoiceRepository.cs
+++ b/src/Coupa.InvoiceSync.Api/Application/Abstractions/IInvoiceRepository.cs
@@ -1,0 +1,21 @@
+using Coupa.InvoiceSync.Api.Domain.Entities;
+
+namespace Coupa.InvoiceSync.Api.Application.Abstractions;
+
+/// <summary>
+/// Persists canonical invoices into a region-specific target database.
+/// </summary>
+public interface IInvoiceRepository
+{
+    /// <summary>
+    /// Gets the routing key used for selecting this repository (for example: "NA:TargetDb").
+    /// </summary>
+    string RouteKey { get; }
+
+    /// <summary>
+    /// Inserts the provided invoice into its target schema.
+    /// </summary>
+    /// <param name="invoice">The normalized invoice instance.</param>
+    /// <param name="cancellationToken">A token that cancels the operation.</param>
+    Task InsertInvoiceAsync(CanonicalInvoice invoice, CancellationToken cancellationToken);
+}

--- a/src/Coupa.InvoiceSync.Api/Application/Abstractions/IInvoiceRepositoryFactory.cs
+++ b/src/Coupa.InvoiceSync.Api/Application/Abstractions/IInvoiceRepositoryFactory.cs
@@ -1,0 +1,15 @@
+namespace Coupa.InvoiceSync.Api.Application.Abstractions;
+
+/// <summary>
+/// Selects a concrete target repository based on region and destination system.
+/// </summary>
+public interface IInvoiceRepositoryFactory
+{
+    /// <summary>
+    /// Resolves the target repository using routing metadata.
+    /// </summary>
+    /// <param name="region">The source region.</param>
+    /// <param name="destinationSystem">The destination system key.</param>
+    /// <returns>A repository instance capable of persisting the invoice.</returns>
+    IInvoiceRepository Resolve(string region, string destinationSystem);
+}

--- a/src/Coupa.InvoiceSync.Api/Application/Abstractions/IInvoiceSyncService.cs
+++ b/src/Coupa.InvoiceSync.Api/Application/Abstractions/IInvoiceSyncService.cs
@@ -1,0 +1,16 @@
+using Coupa.InvoiceSync.Api.Domain.Entities;
+
+namespace Coupa.InvoiceSync.Api.Application.Abstractions;
+
+/// <summary>
+/// Orchestrates the end-to-end invoice synchronization flow.
+/// </summary>
+public interface IInvoiceSyncService
+{
+    /// <summary>
+    /// Synchronizes all invoices from Coupa into the configured target databases.
+    /// </summary>
+    /// <param name="cancellationToken">A token that cancels the operation.</param>
+    /// <returns>The summary of sync execution.</returns>
+    Task<InvoiceSyncResult> SyncAsync(CancellationToken cancellationToken);
+}

--- a/src/Coupa.InvoiceSync.Api/Application/Pipeline/IInvoiceProcessingMiddleware.cs
+++ b/src/Coupa.InvoiceSync.Api/Application/Pipeline/IInvoiceProcessingMiddleware.cs
@@ -1,0 +1,15 @@
+namespace Coupa.InvoiceSync.Api.Application.Pipeline;
+
+/// <summary>
+/// Defines middleware behavior for transforming and validating invoices.
+/// </summary>
+public interface IInvoiceProcessingMiddleware
+{
+    /// <summary>
+    /// Executes middleware logic and delegates to the next component.
+    /// </summary>
+    /// <param name="context">The current processing context.</param>
+    /// <param name="next">The callback to execute the next middleware.</param>
+    /// <param name="cancellationToken">A token that cancels the operation.</param>
+    Task InvokeAsync(InvoiceProcessingContext context, Func<Task> next, CancellationToken cancellationToken);
+}

--- a/src/Coupa.InvoiceSync.Api/Application/Pipeline/IInvoiceProcessingPipeline.cs
+++ b/src/Coupa.InvoiceSync.Api/Application/Pipeline/IInvoiceProcessingPipeline.cs
@@ -1,0 +1,14 @@
+namespace Coupa.InvoiceSync.Api.Application.Pipeline;
+
+/// <summary>
+/// Represents the composed middleware pipeline for invoice processing.
+/// </summary>
+public interface IInvoiceProcessingPipeline
+{
+    /// <summary>
+    /// Executes all registered middlewares in order.
+    /// </summary>
+    /// <param name="context">The processing context.</param>
+    /// <param name="cancellationToken">A token that cancels the operation.</param>
+    Task ExecuteAsync(InvoiceProcessingContext context, CancellationToken cancellationToken);
+}

--- a/src/Coupa.InvoiceSync.Api/Application/Pipeline/InvoiceProcessingContext.cs
+++ b/src/Coupa.InvoiceSync.Api/Application/Pipeline/InvoiceProcessingContext.cs
@@ -1,0 +1,19 @@
+using Coupa.InvoiceSync.Api.Domain.Entities;
+
+namespace Coupa.InvoiceSync.Api.Application.Pipeline;
+
+/// <summary>
+/// Holds state that flows through the invoice processing middleware pipeline.
+/// </summary>
+public sealed class InvoiceProcessingContext
+{
+    /// <summary>
+    /// Gets or sets the source Coupa invoice.
+    /// </summary>
+    public required CoupaInvoice SourceInvoice { get; init; }
+
+    /// <summary>
+    /// Gets or sets the mapped canonical invoice.
+    /// </summary>
+    public CanonicalInvoice CanonicalInvoice { get; set; } = new();
+}

--- a/src/Coupa.InvoiceSync.Api/Application/Pipeline/InvoiceProcessingPipeline.cs
+++ b/src/Coupa.InvoiceSync.Api/Application/Pipeline/InvoiceProcessingPipeline.cs
@@ -1,0 +1,28 @@
+namespace Coupa.InvoiceSync.Api.Application.Pipeline;
+
+/// <summary>
+/// Executes registered middleware components using a chain-of-responsibility pipeline.
+/// </summary>
+public sealed class InvoiceProcessingPipeline(IEnumerable<IInvoiceProcessingMiddleware> middlewares) : IInvoiceProcessingPipeline
+{
+    private readonly IReadOnlyList<IInvoiceProcessingMiddleware> _middlewares = middlewares.ToList();
+
+    /// <inheritdoc />
+    public Task ExecuteAsync(InvoiceProcessingContext context, CancellationToken cancellationToken)
+    {
+        var index = -1;
+
+        Task Next()
+        {
+            index++;
+            if (index >= _middlewares.Count)
+            {
+                return Task.CompletedTask;
+            }
+
+            return _middlewares[index].InvokeAsync(context, Next, cancellationToken);
+        }
+
+        return Next();
+    }
+}

--- a/src/Coupa.InvoiceSync.Api/Application/Services/InvoiceSyncService.cs
+++ b/src/Coupa.InvoiceSync.Api/Application/Services/InvoiceSyncService.cs
@@ -1,0 +1,52 @@
+using System.Text.Json;
+using Coupa.InvoiceSync.Api.Application.Abstractions;
+using Coupa.InvoiceSync.Api.Application.Pipeline;
+using Coupa.InvoiceSync.Api.Domain.Entities;
+
+namespace Coupa.InvoiceSync.Api.Application.Services;
+
+/// <summary>
+/// Coordinates invoice retrieval, mapping, routing, persistence, and staging error handling.
+/// </summary>
+public sealed class InvoiceSyncService(
+    ICoupaInvoiceClient coupaInvoiceClient,
+    IInvoiceProcessingPipeline processingPipeline,
+    IInvoiceRepositoryFactory invoiceRepositoryFactory,
+    IErrorStagingRepository errorStagingRepository) : IInvoiceSyncService
+{
+    /// <inheritdoc />
+    public async Task<InvoiceSyncResult> SyncAsync(CancellationToken cancellationToken)
+    {
+        var invoices = await coupaInvoiceClient.GetInvoicesAsync(cancellationToken);
+        var result = new InvoiceSyncResult();
+
+        foreach (var invoice in invoices)
+        {
+            try
+            {
+                var context = new InvoiceProcessingContext
+                {
+                    SourceInvoice = invoice
+                };
+
+                await processingPipeline.ExecuteAsync(context, cancellationToken);
+
+                var repository = invoiceRepositoryFactory.Resolve(context.CanonicalInvoice.Region, context.CanonicalInvoice.DestinationSystem);
+                await repository.InsertInvoiceAsync(context.CanonicalInvoice, cancellationToken);
+                result.Succeeded++;
+            }
+            catch (Exception exception)
+            {
+                var payload = JsonSerializer.Serialize(invoice.Payload);
+                await errorStagingRepository.InsertErrorAsync(invoice.InvoiceId, payload, exception.Message, cancellationToken);
+                result.Failed++;
+            }
+        }
+
+        result.Message = result.Failed == 0
+            ? $"Successfully inserted {result.Succeeded} invoices into target databases."
+            : $"Inserted {result.Succeeded} invoices with {result.Failed} error records staged.";
+
+        return result;
+    }
+}

--- a/src/Coupa.InvoiceSync.Api/Contracts/CoupaInvoicesResponse.cs
+++ b/src/Coupa.InvoiceSync.Api/Contracts/CoupaInvoicesResponse.cs
@@ -1,0 +1,51 @@
+using System.Text.Json.Serialization;
+
+namespace Coupa.InvoiceSync.Api.Contracts;
+
+/// <summary>
+/// Represents a simplified Coupa API response envelope.
+/// </summary>
+public sealed class CoupaInvoicesResponse
+{
+    /// <summary>
+    /// Gets or sets invoice entries returned by Coupa.
+    /// </summary>
+    [JsonPropertyName("invoices")]
+    public List<CoupaInvoiceRecord> Invoices { get; set; } = [];
+}
+
+/// <summary>
+/// Represents a single invoice item returned from Coupa.
+/// </summary>
+public sealed class CoupaInvoiceRecord
+{
+    /// <summary>
+    /// Gets or sets invoice id.
+    /// </summary>
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+
+    /// <summary>
+    /// Gets or sets region.
+    /// </summary>
+    [JsonPropertyName("region")]
+    public required string Region { get; init; }
+
+    /// <summary>
+    /// Gets or sets invoice type.
+    /// </summary>
+    [JsonPropertyName("invoice_type")]
+    public required string InvoiceType { get; init; }
+
+    /// <summary>
+    /// Gets or sets downstream destination system.
+    /// </summary>
+    [JsonPropertyName("destination_system")]
+    public string DestinationSystem { get; init; } = "TargetDb";
+
+    /// <summary>
+    /// Gets or sets invoice payload.
+    /// </summary>
+    [JsonPropertyName("payload")]
+    public required System.Text.Json.JsonElement Payload { get; init; }
+}

--- a/src/Coupa.InvoiceSync.Api/Controllers/InvoiceSyncController.cs
+++ b/src/Coupa.InvoiceSync.Api/Controllers/InvoiceSyncController.cs
@@ -1,0 +1,26 @@
+using Coupa.InvoiceSync.Api.Application.Abstractions;
+using Coupa.InvoiceSync.Api.Domain.Entities;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Coupa.InvoiceSync.Api.Controllers;
+
+/// <summary>
+/// Exposes API endpoints for Coupa invoice synchronization operations.
+/// </summary>
+[ApiController]
+[Route("api/invoices")]
+public sealed class InvoiceSyncController(IInvoiceSyncService invoiceSyncService) : ControllerBase
+{
+    /// <summary>
+    /// Pulls invoices from Coupa, maps them, inserts them into target databases, and returns a sync summary.
+    /// </summary>
+    /// <param name="cancellationToken">A token that cancels the operation.</param>
+    /// <returns>The synchronization result summary.</returns>
+    [HttpPost("sync")]
+    [ProducesResponseType(typeof(InvoiceSyncResult), StatusCodes.Status200OK)]
+    public async Task<IActionResult> SyncInvoices(CancellationToken cancellationToken)
+    {
+        var result = await invoiceSyncService.SyncAsync(cancellationToken);
+        return Ok(result);
+    }
+}

--- a/src/Coupa.InvoiceSync.Api/Coupa.InvoiceSync.Api.csproj
+++ b/src/Coupa.InvoiceSync.Api/Coupa.InvoiceSync.Api.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+  </PropertyGroup>
+</Project>

--- a/src/Coupa.InvoiceSync.Api/Domain/Entities/CanonicalInvoice.cs
+++ b/src/Coupa.InvoiceSync.Api/Domain/Entities/CanonicalInvoice.cs
@@ -1,0 +1,54 @@
+using Coupa.InvoiceSync.Api.Domain.Enums;
+
+namespace Coupa.InvoiceSync.Api.Domain.Entities;
+
+/// <summary>
+/// Represents a normalized invoice model used across mapping and persistence workflows.
+/// </summary>
+public sealed class CanonicalInvoice
+{
+    /// <summary>
+    /// Gets or sets the external invoice identifier.
+    /// </summary>
+    public string InvoiceId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the invoice number.
+    /// </summary>
+    public string InvoiceNumber { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the invoice region.
+    /// </summary>
+    public string Region { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the downstream target system.
+    /// </summary>
+    public string DestinationSystem { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the invoice supplier name.
+    /// </summary>
+    public string SupplierName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the invoice currency code.
+    /// </summary>
+    public string CurrencyCode { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the invoice amount.
+    /// </summary>
+    public decimal Amount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the invoice issue date.
+    /// </summary>
+    public DateTimeOffset IssueDate { get; set; }
+
+    /// <summary>
+    /// Gets or sets the normalized invoice category.
+    /// </summary>
+    public InvoiceCategory Category { get; set; } = InvoiceCategory.Unknown;
+}

--- a/src/Coupa.InvoiceSync.Api/Domain/Entities/CoupaInvoice.cs
+++ b/src/Coupa.InvoiceSync.Api/Domain/Entities/CoupaInvoice.cs
@@ -1,0 +1,34 @@
+using System.Text.Json;
+
+namespace Coupa.InvoiceSync.Api.Domain.Entities;
+
+/// <summary>
+/// Represents a raw invoice payload returned by Coupa's Get Invoices API.
+/// </summary>
+public sealed class CoupaInvoice
+{
+    /// <summary>
+    /// Gets or sets the Coupa invoice identifier.
+    /// </summary>
+    public required string InvoiceId { get; init; }
+
+    /// <summary>
+    /// Gets or sets the region that determines the destination target database.
+    /// </summary>
+    public required string Region { get; init; }
+
+    /// <summary>
+    /// Gets or sets the source invoice type.
+    /// </summary>
+    public required string InvoiceType { get; init; }
+
+    /// <summary>
+    /// Gets or sets the downstream destination system key such as "TargetDb" or "MSDynamics".
+    /// </summary>
+    public string DestinationSystem { get; init; } = "TargetDb";
+
+    /// <summary>
+    /// Gets or sets the full source payload as a JSON object.
+    /// </summary>
+    public required JsonElement Payload { get; init; }
+}

--- a/src/Coupa.InvoiceSync.Api/Domain/Entities/InvoiceSyncResult.cs
+++ b/src/Coupa.InvoiceSync.Api/Domain/Entities/InvoiceSyncResult.cs
@@ -1,0 +1,22 @@
+namespace Coupa.InvoiceSync.Api.Domain.Entities;
+
+/// <summary>
+/// Represents the aggregate result returned after processing all invoices.
+/// </summary>
+public sealed class InvoiceSyncResult
+{
+    /// <summary>
+    /// Gets or sets the number of invoices successfully persisted.
+    /// </summary>
+    public int Succeeded { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of invoices written to staging error storage.
+    /// </summary>
+    public int Failed { get; set; }
+
+    /// <summary>
+    /// Gets or sets the final status message presented in API responses.
+    /// </summary>
+    public string Message { get; set; } = string.Empty;
+}

--- a/src/Coupa.InvoiceSync.Api/Domain/Enums/InvoiceCategory.cs
+++ b/src/Coupa.InvoiceSync.Api/Domain/Enums/InvoiceCategory.cs
@@ -1,0 +1,27 @@
+namespace Coupa.InvoiceSync.Api.Domain.Enums;
+
+/// <summary>
+/// Defines the supported invoice categories received from Coupa.
+/// </summary>
+public enum InvoiceCategory
+{
+    /// <summary>
+    /// Represents standard purchase invoices.
+    /// </summary>
+    Purchase,
+
+    /// <summary>
+    /// Represents licensing purchase invoices.
+    /// </summary>
+    Licensing,
+
+    /// <summary>
+    /// Represents resource billing invoices.
+    /// </summary>
+    ResourceBilling,
+
+    /// <summary>
+    /// Represents invoices that do not match a known category.
+    /// </summary>
+    Unknown
+}

--- a/src/Coupa.InvoiceSync.Api/Infrastructure/Coupa/CoupaInvoiceClient.cs
+++ b/src/Coupa.InvoiceSync.Api/Infrastructure/Coupa/CoupaInvoiceClient.cs
@@ -1,0 +1,41 @@
+using System.Text.Json;
+using Coupa.InvoiceSync.Api.Application.Abstractions;
+using Coupa.InvoiceSync.Api.Contracts;
+using Coupa.InvoiceSync.Api.Domain.Entities;
+using Coupa.InvoiceSync.Api.Infrastructure.Options;
+using Microsoft.Extensions.Options;
+
+namespace Coupa.InvoiceSync.Api.Infrastructure.Coupa;
+
+/// <summary>
+/// Calls Coupa REST endpoints and transforms responses into domain entities.
+/// </summary>
+public sealed class CoupaInvoiceClient(HttpClient httpClient, IOptions<CoupaApiOptions> options) : ICoupaInvoiceClient
+{
+    private readonly CoupaApiOptions _options = options.Value;
+
+    /// <inheritdoc />
+    public async Task<IReadOnlyCollection<CoupaInvoice>> GetInvoicesAsync(CancellationToken cancellationToken)
+    {
+        using var request = new HttpRequestMessage(HttpMethod.Get, _options.GetInvoicesPath);
+        request.Headers.Add("X-COUPA-API-KEY", _options.ApiKey);
+
+        using var response = await httpClient.SendAsync(request, cancellationToken);
+        response.EnsureSuccessStatusCode();
+
+        await using var stream = await response.Content.ReadAsStreamAsync(cancellationToken);
+        var payload = await JsonSerializer.DeserializeAsync<CoupaInvoicesResponse>(stream, cancellationToken: cancellationToken)
+            ?? new CoupaInvoicesResponse();
+
+        return payload.Invoices
+            .Select(invoice => new CoupaInvoice
+            {
+                InvoiceId = invoice.Id,
+                Region = invoice.Region,
+                InvoiceType = invoice.InvoiceType,
+                DestinationSystem = invoice.DestinationSystem,
+                Payload = invoice.Payload
+            })
+            .ToArray();
+    }
+}

--- a/src/Coupa.InvoiceSync.Api/Infrastructure/Mapping/GenericInvoiceMappingMiddleware.cs
+++ b/src/Coupa.InvoiceSync.Api/Infrastructure/Mapping/GenericInvoiceMappingMiddleware.cs
@@ -1,0 +1,67 @@
+using System.Globalization;
+using System.Reflection;
+using Coupa.InvoiceSync.Api.Application.Pipeline;
+using Coupa.InvoiceSync.Api.Domain.Entities;
+using Coupa.InvoiceSync.Api.Domain.Enums;
+using Coupa.InvoiceSync.Api.Infrastructure.Options;
+using Microsoft.Extensions.Options;
+
+namespace Coupa.InvoiceSync.Api.Infrastructure.Mapping;
+
+/// <summary>
+/// Maps source Coupa payload fields into a canonical invoice model using configurable field maps.
+/// </summary>
+public sealed class GenericInvoiceMappingMiddleware(IOptions<MappingOptions> options) : IInvoiceProcessingMiddleware
+{
+    private readonly MappingOptions _mappingOptions = options.Value;
+
+    /// <inheritdoc />
+    public Task InvokeAsync(InvoiceProcessingContext context, Func<Task> next, CancellationToken cancellationToken)
+    {
+        var profile = _mappingOptions.Profiles.GetValueOrDefault("CoupaToCanonical")
+            ?? throw new InvalidOperationException("Mapping profile 'CoupaToCanonical' is missing.");
+
+        var canonical = new CanonicalInvoice();
+        foreach (var fieldMap in profile.FieldMappings)
+        {
+            if (!context.SourceInvoice.Payload.TryGetProperty(fieldMap.SourceField, out var sourceValue))
+            {
+                continue;
+            }
+
+            SetTargetValue(canonical, fieldMap.TargetField, sourceValue);
+        }
+
+        canonical.InvoiceId = context.SourceInvoice.InvoiceId;
+        canonical.Region = context.SourceInvoice.Region;
+        canonical.DestinationSystem = context.SourceInvoice.DestinationSystem;
+        canonical.Category = NormalizeCategory(context.SourceInvoice.InvoiceType);
+        context.CanonicalInvoice = canonical;
+
+        return next();
+    }
+
+    private static void SetTargetValue(CanonicalInvoice invoice, string targetField, System.Text.Json.JsonElement sourceValue)
+    {
+        var property = typeof(CanonicalInvoice).GetProperty(targetField, BindingFlags.Public | BindingFlags.Instance | BindingFlags.IgnoreCase)
+            ?? throw new InvalidOperationException($"Target field '{targetField}' does not exist on CanonicalInvoice.");
+
+        object convertedValue = property.PropertyType.Name switch
+        {
+            nameof(String) => sourceValue.GetString() ?? string.Empty,
+            nameof(Decimal) => sourceValue.GetDecimal(),
+            nameof(DateTimeOffset) => DateTimeOffset.Parse(sourceValue.GetString() ?? DateTimeOffset.UtcNow.ToString("O", CultureInfo.InvariantCulture), CultureInfo.InvariantCulture),
+            _ => throw new InvalidOperationException($"Type '{property.PropertyType.Name}' is not supported by the mapping middleware.")
+        };
+
+        property.SetValue(invoice, convertedValue);
+    }
+
+    private static InvoiceCategory NormalizeCategory(string sourceType) => sourceType.ToLowerInvariant() switch
+    {
+        "purchase" => InvoiceCategory.Purchase,
+        "licensing" => InvoiceCategory.Licensing,
+        "resource" => InvoiceCategory.ResourceBilling,
+        _ => InvoiceCategory.Unknown
+    };
+}

--- a/src/Coupa.InvoiceSync.Api/Infrastructure/Mapping/InvoiceTypeValidationMiddleware.cs
+++ b/src/Coupa.InvoiceSync.Api/Infrastructure/Mapping/InvoiceTypeValidationMiddleware.cs
@@ -1,0 +1,26 @@
+using Coupa.InvoiceSync.Api.Application.Pipeline;
+using Coupa.InvoiceSync.Api.Domain.Enums;
+
+namespace Coupa.InvoiceSync.Api.Infrastructure.Mapping;
+
+/// <summary>
+/// Validates mandatory fields after mapping and blocks unsupported invoice content.
+/// </summary>
+public sealed class InvoiceTypeValidationMiddleware : IInvoiceProcessingMiddleware
+{
+    /// <inheritdoc />
+    public Task InvokeAsync(InvoiceProcessingContext context, Func<Task> next, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(context.CanonicalInvoice.InvoiceNumber))
+        {
+            throw new InvalidOperationException("InvoiceNumber is required after mapping.");
+        }
+
+        if (context.CanonicalInvoice.Category == InvoiceCategory.Unknown)
+        {
+            throw new InvalidOperationException("Invoice type is unsupported for processing.");
+        }
+
+        return next();
+    }
+}

--- a/src/Coupa.InvoiceSync.Api/Infrastructure/Options/CoupaApiOptions.cs
+++ b/src/Coupa.InvoiceSync.Api/Infrastructure/Options/CoupaApiOptions.cs
@@ -1,0 +1,27 @@
+namespace Coupa.InvoiceSync.Api.Infrastructure.Options;
+
+/// <summary>
+/// Stores Coupa API connectivity settings.
+/// </summary>
+public sealed class CoupaApiOptions
+{
+    /// <summary>
+    /// Gets the configuration section name.
+    /// </summary>
+    public const string SectionName = "CoupaApi";
+
+    /// <summary>
+    /// Gets or sets Coupa base URL.
+    /// </summary>
+    public string BaseUrl { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets relative Get Invoices endpoint path.
+    /// </summary>
+    public string GetInvoicesPath { get; set; } = "/api/invoices";
+
+    /// <summary>
+    /// Gets or sets Coupa API key.
+    /// </summary>
+    public string ApiKey { get; set; } = string.Empty;
+}

--- a/src/Coupa.InvoiceSync.Api/Infrastructure/Options/MappingOptions.cs
+++ b/src/Coupa.InvoiceSync.Api/Infrastructure/Options/MappingOptions.cs
@@ -1,0 +1,49 @@
+namespace Coupa.InvoiceSync.Api.Infrastructure.Options;
+
+/// <summary>
+/// Defines configurable source-to-target mapping profiles.
+/// </summary>
+public sealed class MappingOptions
+{
+    /// <summary>
+    /// Gets the configuration section name.
+    /// </summary>
+    public const string SectionName = "Mapping";
+
+    /// <summary>
+    /// Gets or sets named profiles for source-to-target mapping.
+    /// </summary>
+    public Dictionary<string, MappingProfile> Profiles { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+}
+
+/// <summary>
+/// Represents one mapping profile containing field-level mappings.
+/// </summary>
+public sealed class MappingProfile
+{
+    /// <summary>
+    /// Gets or sets the profile name.
+    /// </summary>
+    public string Name { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets configured field mappings.
+    /// </summary>
+    public List<FieldMapping> FieldMappings { get; set; } = [];
+}
+
+/// <summary>
+/// Represents a source field to target field mapping.
+/// </summary>
+public sealed class FieldMapping
+{
+    /// <summary>
+    /// Gets or sets source field name from Coupa payload.
+    /// </summary>
+    public string SourceField { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets target field name for canonical model.
+    /// </summary>
+    public string TargetField { get; set; } = string.Empty;
+}

--- a/src/Coupa.InvoiceSync.Api/Infrastructure/Options/RoutingOptions.cs
+++ b/src/Coupa.InvoiceSync.Api/Infrastructure/Options/RoutingOptions.cs
@@ -1,0 +1,17 @@
+namespace Coupa.InvoiceSync.Api.Infrastructure.Options;
+
+/// <summary>
+/// Contains route keys used to map regions and systems to target repositories.
+/// </summary>
+public sealed class RoutingOptions
+{
+    /// <summary>
+    /// Gets the configuration section name.
+    /// </summary>
+    public const string SectionName = "Routing";
+
+    /// <summary>
+    /// Gets or sets dictionary mapping route keys to repository keys.
+    /// </summary>
+    public Dictionary<string, string> RouteToRepository { get; set; } = new(StringComparer.OrdinalIgnoreCase);
+}

--- a/src/Coupa.InvoiceSync.Api/Infrastructure/Persistence/EuropeSqlInvoiceRepository.cs
+++ b/src/Coupa.InvoiceSync.Api/Infrastructure/Persistence/EuropeSqlInvoiceRepository.cs
@@ -1,0 +1,22 @@
+using Coupa.InvoiceSync.Api.Application.Abstractions;
+using Coupa.InvoiceSync.Api.Domain.Entities;
+
+namespace Coupa.InvoiceSync.Api.Infrastructure.Persistence;
+
+/// <summary>
+/// Persists Europe invoices to a region-specific target database.
+/// </summary>
+public sealed class EuropeSqlInvoiceRepository : IInvoiceRepository
+{
+    private static readonly List<CanonicalInvoice> Invoices = [];
+
+    /// <inheritdoc />
+    public string RouteKey => "EU:TargetDb";
+
+    /// <inheritdoc />
+    public Task InsertInvoiceAsync(CanonicalInvoice invoice, CancellationToken cancellationToken)
+    {
+        Invoices.Add(invoice);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Coupa.InvoiceSync.Api/Infrastructure/Persistence/InMemoryErrorStagingRepository.cs
+++ b/src/Coupa.InvoiceSync.Api/Infrastructure/Persistence/InMemoryErrorStagingRepository.cs
@@ -1,0 +1,51 @@
+using Coupa.InvoiceSync.Api.Application.Abstractions;
+
+namespace Coupa.InvoiceSync.Api.Infrastructure.Persistence;
+
+/// <summary>
+/// Stores failed invoice payloads in an in-memory collection that represents a staging error table.
+/// </summary>
+public sealed class InMemoryErrorStagingRepository : IErrorStagingRepository
+{
+    private static readonly List<StagingErrorRecord> ErrorRows = [];
+
+    /// <inheritdoc />
+    public Task InsertErrorAsync(string invoiceId, string payload, string error, CancellationToken cancellationToken)
+    {
+        ErrorRows.Add(new StagingErrorRecord
+        {
+            InvoiceId = invoiceId,
+            Payload = payload,
+            Error = error,
+            CreatedUtc = DateTimeOffset.UtcNow
+        });
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Represents one staging error row.
+    /// </summary>
+    private sealed class StagingErrorRecord
+    {
+        /// <summary>
+        /// Gets or sets invoice id.
+        /// </summary>
+        public string InvoiceId { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets failed payload JSON.
+        /// </summary>
+        public string Payload { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets exception message.
+        /// </summary>
+        public string Error { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets error creation timestamp.
+        /// </summary>
+        public DateTimeOffset CreatedUtc { get; set; }
+    }
+}

--- a/src/Coupa.InvoiceSync.Api/Infrastructure/Persistence/IndiaSqlInvoiceRepository.cs
+++ b/src/Coupa.InvoiceSync.Api/Infrastructure/Persistence/IndiaSqlInvoiceRepository.cs
@@ -1,0 +1,22 @@
+using Coupa.InvoiceSync.Api.Application.Abstractions;
+using Coupa.InvoiceSync.Api.Domain.Entities;
+
+namespace Coupa.InvoiceSync.Api.Infrastructure.Persistence;
+
+/// <summary>
+/// Persists India invoices to a region-specific target database.
+/// </summary>
+public sealed class IndiaSqlInvoiceRepository : IInvoiceRepository
+{
+    private static readonly List<CanonicalInvoice> Invoices = [];
+
+    /// <inheritdoc />
+    public string RouteKey => "IN:TargetDb";
+
+    /// <inheritdoc />
+    public Task InsertInvoiceAsync(CanonicalInvoice invoice, CancellationToken cancellationToken)
+    {
+        Invoices.Add(invoice);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Coupa.InvoiceSync.Api/Infrastructure/Persistence/InvoiceRepositoryFactory.cs
+++ b/src/Coupa.InvoiceSync.Api/Infrastructure/Persistence/InvoiceRepositoryFactory.cs
@@ -1,0 +1,35 @@
+using Coupa.InvoiceSync.Api.Application.Abstractions;
+using Coupa.InvoiceSync.Api.Infrastructure.Options;
+using Microsoft.Extensions.Options;
+
+namespace Coupa.InvoiceSync.Api.Infrastructure.Persistence;
+
+/// <summary>
+/// Resolves destination repositories based on configurable route-to-repository mappings.
+/// </summary>
+public sealed class InvoiceRepositoryFactory(
+    IEnumerable<IInvoiceRepository> repositories,
+    IOptions<RoutingOptions> routingOptions) : IInvoiceRepositoryFactory
+{
+    private readonly Dictionary<string, IInvoiceRepository> _repositoryByName = repositories
+        .ToDictionary(repository => repository.GetType().Name, StringComparer.OrdinalIgnoreCase);
+
+    private readonly RoutingOptions _routingOptions = routingOptions.Value;
+
+    /// <inheritdoc />
+    public IInvoiceRepository Resolve(string region, string destinationSystem)
+    {
+        var routeKey = $"{region}:{destinationSystem}";
+        if (!_routingOptions.RouteToRepository.TryGetValue(routeKey, out var repositoryName))
+        {
+            throw new KeyNotFoundException($"No route mapping exists for '{routeKey}'.");
+        }
+
+        if (_repositoryByName.TryGetValue(repositoryName, out var repository))
+        {
+            return repository;
+        }
+
+        throw new KeyNotFoundException($"Repository '{repositoryName}' was not registered for route '{routeKey}'.");
+    }
+}

--- a/src/Coupa.InvoiceSync.Api/Infrastructure/Persistence/MsDynamicsInvoiceRepository.cs
+++ b/src/Coupa.InvoiceSync.Api/Infrastructure/Persistence/MsDynamicsInvoiceRepository.cs
@@ -1,0 +1,22 @@
+using Coupa.InvoiceSync.Api.Application.Abstractions;
+using Coupa.InvoiceSync.Api.Domain.Entities;
+
+namespace Coupa.InvoiceSync.Api.Infrastructure.Persistence;
+
+/// <summary>
+/// Persists invoices for Microsoft Dynamics integration, demonstrating third-party target extensibility.
+/// </summary>
+public sealed class MsDynamicsInvoiceRepository : IInvoiceRepository
+{
+    private static readonly List<CanonicalInvoice> Invoices = [];
+
+    /// <inheritdoc />
+    public string RouteKey => "NA:MSDynamics";
+
+    /// <inheritdoc />
+    public Task InsertInvoiceAsync(CanonicalInvoice invoice, CancellationToken cancellationToken)
+    {
+        Invoices.Add(invoice);
+        return Task.CompletedTask;
+    }
+}

--- a/src/Coupa.InvoiceSync.Api/Infrastructure/Persistence/NorthAmericaSqlInvoiceRepository.cs
+++ b/src/Coupa.InvoiceSync.Api/Infrastructure/Persistence/NorthAmericaSqlInvoiceRepository.cs
@@ -1,0 +1,42 @@
+using Coupa.InvoiceSync.Api.Application.Abstractions;
+using Coupa.InvoiceSync.Api.Domain.Entities;
+
+namespace Coupa.InvoiceSync.Api.Infrastructure.Persistence;
+
+/// <summary>
+/// Persists North America invoices to a region-specific target database.
+/// </summary>
+public sealed class NorthAmericaSqlInvoiceRepository : IInvoiceRepository
+{
+    private static readonly List<CanonicalInvoice> PurchaseInvoices = [];
+    private static readonly List<CanonicalInvoice> LicensingInvoices = [];
+    private static readonly List<CanonicalInvoice> ResourceInvoices = [];
+
+    /// <inheritdoc />
+    public string RouteKey => "NA:TargetDb";
+
+    /// <inheritdoc />
+    public Task InsertInvoiceAsync(CanonicalInvoice invoice, CancellationToken cancellationToken)
+    {
+        InsertByCategory(invoice);
+        return Task.CompletedTask;
+    }
+
+    private static void InsertByCategory(CanonicalInvoice invoice)
+    {
+        switch (invoice.Category)
+        {
+            case Domain.Enums.InvoiceCategory.Purchase:
+                PurchaseInvoices.Add(invoice);
+                break;
+            case Domain.Enums.InvoiceCategory.Licensing:
+                LicensingInvoices.Add(invoice);
+                break;
+            case Domain.Enums.InvoiceCategory.ResourceBilling:
+                ResourceInvoices.Add(invoice);
+                break;
+            default:
+                throw new InvalidOperationException("Invoice category is not supported by the North America target database.");
+        }
+    }
+}

--- a/src/Coupa.InvoiceSync.Api/Program.cs
+++ b/src/Coupa.InvoiceSync.Api/Program.cs
@@ -1,0 +1,46 @@
+using Coupa.InvoiceSync.Api.Application.Abstractions;
+using Coupa.InvoiceSync.Api.Application.Pipeline;
+using Coupa.InvoiceSync.Api.Application.Services;
+using Coupa.InvoiceSync.Api.Infrastructure.Coupa;
+using Coupa.InvoiceSync.Api.Infrastructure.Mapping;
+using Coupa.InvoiceSync.Api.Infrastructure.Options;
+using Coupa.InvoiceSync.Api.Infrastructure.Persistence;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.Services.Configure<CoupaApiOptions>(builder.Configuration.GetSection(CoupaApiOptions.SectionName));
+builder.Services.Configure<MappingOptions>(builder.Configuration.GetSection(MappingOptions.SectionName));
+builder.Services.Configure<RoutingOptions>(builder.Configuration.GetSection(RoutingOptions.SectionName));
+
+builder.Services.AddHttpClient<ICoupaInvoiceClient, CoupaInvoiceClient>((serviceProvider, client) =>
+{
+    var options = serviceProvider.GetRequiredService<Microsoft.Extensions.Options.IOptions<CoupaApiOptions>>().Value;
+    client.BaseAddress = new Uri(options.BaseUrl);
+});
+builder.Services.AddSingleton<IErrorStagingRepository, InMemoryErrorStagingRepository>();
+builder.Services.AddSingleton<IInvoiceRepositoryFactory, InvoiceRepositoryFactory>();
+builder.Services.AddSingleton<IInvoiceRepository, NorthAmericaSqlInvoiceRepository>();
+builder.Services.AddSingleton<IInvoiceRepository, EuropeSqlInvoiceRepository>();
+builder.Services.AddSingleton<IInvoiceRepository, IndiaSqlInvoiceRepository>();
+builder.Services.AddSingleton<IInvoiceRepository, MsDynamicsInvoiceRepository>();
+
+builder.Services.AddSingleton<IInvoiceProcessingMiddleware, GenericInvoiceMappingMiddleware>();
+builder.Services.AddSingleton<IInvoiceProcessingMiddleware, InvoiceTypeValidationMiddleware>();
+builder.Services.AddSingleton<IInvoiceProcessingPipeline, InvoiceProcessingPipeline>();
+builder.Services.AddScoped<IInvoiceSyncService, InvoiceSyncService>();
+
+builder.Services.AddControllers();
+builder.Services.AddEndpointsApiExplorer();
+builder.Services.AddSwaggerGen();
+
+var app = builder.Build();
+
+if (app.Environment.IsDevelopment())
+{
+    app.UseSwagger();
+    app.UseSwaggerUI();
+}
+
+app.UseHttpsRedirection();
+app.MapControllers();
+app.Run();

--- a/src/Coupa.InvoiceSync.Api/appsettings.json
+++ b/src/Coupa.InvoiceSync.Api/appsettings.json
@@ -1,0 +1,35 @@
+{
+  "CoupaApi": {
+    "BaseUrl": "https://coupa.example.com",
+    "GetInvoicesPath": "/api/invoices",
+    "ApiKey": "replace-with-secret"
+  },
+  "Mapping": {
+    "Profiles": {
+      "CoupaToCanonical": {
+        "Name": "CoupaToCanonical",
+        "FieldMappings": [
+          { "SourceField": "invoice_number", "TargetField": "InvoiceNumber" },
+          { "SourceField": "supplier_name", "TargetField": "SupplierName" },
+          { "SourceField": "currency", "TargetField": "CurrencyCode" },
+          { "SourceField": "amount", "TargetField": "Amount" },
+          { "SourceField": "issue_date", "TargetField": "IssueDate" }
+        ]
+      }
+    }
+  },
+  "Routing": {
+    "RouteToRepository": {
+      "NA:TargetDb": "NorthAmericaSqlInvoiceRepository",
+      "EU:TargetDb": "EuropeSqlInvoiceRepository",
+      "IN:TargetDb": "IndiaSqlInvoiceRepository",
+      "NA:MSDynamics": "MsDynamicsInvoiceRepository"
+    }
+  },
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide a reusable Web API to call Coupa's Get Invoices API, normalize invoices, route them to region/target-specific sinks, and stage failed records as raw JSON for reprocessing.
- Make source→target field mapping generic and configuration-driven so new invoice types or third-party targets (e.g. MS Dynamics) can be onboarded without code changes.
- Follow SOLID and layered architecture (Domain/Application/Infrastructure/Controllers) and use typed configuration for operational flexibility.

### Description
- Added a new `net10.0` Web API project scaffold under `src/Coupa.InvoiceSync.Api` with `Program.cs` wiring for DI, `Swagger`, and controller routing; configuration is read from `appsettings.json` using typed options (`CoupaApiOptions`, `MappingOptions`, `RoutingOptions`).
- Implemented `ICoupaInvoiceClient` and `CoupaInvoiceClient` to call Coupa, add API key header, and transform responses into `CoupaInvoice` domain entities.
- Introduced a middleware-style mapping pipeline (`IInvoiceProcessingMiddleware`, `IInvoiceProcessingPipeline`, `InvoiceProcessingPipeline`) with a `GenericInvoiceMappingMiddleware` that applies configurable `FieldMapping` profiles and performs type conversion and category normalization, plus `InvoiceTypeValidationMiddleware` to enforce required mapped fields.
- Added orchestration service `InvoiceSyncService` to fetch invoices, run the pipeline, resolve the target repository via `InvoiceRepositoryFactory` and persist invoices; errors are written to a staging error repository (`IErrorStagingRepository` / `InMemoryErrorStagingRepository`) as JSON payloads.
- Implemented pluggable repositories for region/destination (in-memory placeholders): `NorthAmericaSqlInvoiceRepository`, `EuropeSqlInvoiceRepository`, `IndiaSqlInvoiceRepository`, and `MsDynamicsInvoiceRepository`; routing is driven by `Routing:RouteToRepository` entries in `appsettings.json`.
- Created domain models (`CoupaInvoice`, `CanonicalInvoice`, `InvoiceSyncResult`, `InvoiceCategory`) and contract model `CoupaInvoicesResponse`; added XML summaries to classes and methods and updated `README.md` documenting architecture and mapping/routing configuration.

### Testing
- Attempted to build the solution with `dotnet build Coupa.InvoiceSync.sln`, but the build failed because `dotnet` is not installed in the execution environment (automated build attempt failed).
- No unit tests were included in this scaffold; runtime/behavior validation should be performed in an environment with the .NET SDK installed and with concrete persistence adapters configured to replace the in-memory placeholders.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c3412b52c8324b82bc13ee5bd3a83)