### PR TITLE
Add integration controller end-to-end tests, refactor controller, simplify TokenProvider, and update docs/tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,106 +1,28 @@
-# Generic Integration Engine (.NET 10)
+# Coupa Supplier Integration API
 
-## Architecture
-This solution now includes a reusable **metadata-driven Integration Engine** aligned with Clean Architecture:
+Small .NET 10 service for syncing suppliers from Coupa into target systems.
 
-- `src/Coupa.Supplier.Api` → Integration.Host (REST API, middleware, observability)
-- `src/Coupa.Supplier.Application` → orchestration/use-case logic
-- `src/Coupa.Supplier.Domain` → abstractions + integration contracts
-- `src/Coupa.Supplier.Infrastructure` → providers, factories, mapping, persistence
-- `src/Coupa.Supplier.Shared` → shared utility models
+## Projects
+- `src/Coupa.Supplier.Api` - HTTP endpoints and middleware.
+- `src/Coupa.Supplier.Application` - sync orchestration and validation.
+- `src/Coupa.Supplier.Domain` - core contracts/models.
+- `src/Coupa.Supplier.Infrastructure` - repository, providers, and external clients.
+- `tests/Coupa.Supplier.Infrastructure.Tests` - unit tests (mocked, no DB calls).
 
-## Key capabilities delivered
-- Bi-directional integration orchestration (`Inbound`, `Outbound`).
-- Config-driven source/target/mapping loaded by integration name.
-- Dynamic provider selection via factory pattern (no switch-case mapping logic).
-- Target providers:
-  - Oracle India
-  - Oracle US
-  - SQL Server
-  - MS Dynamics
-  - Coupa outbound provider
-- Processing modes:
-  - Single record mode
-  - Bulk mode (batch + configurable parallelism)
-- Record-level error capture into SQL Server staging log table (`dbo.IntegrationErrorLog`).
-- Mapping engine features:
-  - JSONPath-like extraction (`$`, `$.x`, `$.collection[*]`)
-  - Nested/parent-child table ordering
-  - Parent key propagation
-  - Expressions: `constant()`, `now()`, `guid()`, `sequence()`, `upper()`, `concat()`
+## Main endpoints
+- `POST /api/suppliers/sync`
+- `POST /api/integration/run/{integrationName}`
+- `POST /api/integration/outbound/{integrationName}`
 
-## Main contracts
-### Domain Abstractions
-- `IIntegrationOrchestrator`
-- `IIntegrationConfigProvider`
-- `ISourceProvider`, `ISourceProviderFactory`
-- `ITargetProvider`, `ITargetProviderFactory`
-- `IMappingEngine`
-- `IErrorLogService`
-- `ISequenceGenerator`
+## Configuration
+Set values in `src/Coupa.Supplier.Api/appsettings.json` (or environment variables):
+- `Coupa:BaseUrl`
+- `Coupa:SuppliersEndpoint`
+- `Coupa:BearerToken`
+- `ConnectionStrings:OraclePrimary`
 
-### Mapping Output
-`IMappingEngine.Transform(...)` returns:
-
-```csharp
-Dictionary<string, TableBatchData>
+## Run and test
+```bash
+dotnet build Coupa.Supplier.sln
+dotnet test Coupa.Supplier.sln
 ```
-
-Where each `TableBatchData` contains:
-- `TableName`
-- `ColumnData` (`Dictionary<string, List<object?>>`)
-- `RowCount`
-
-## Runtime endpoint
-Run an integration dynamically by name:
-
-```http
-POST /api/integration/run/{integrationName}
-POST /api/integration/outbound/{integrationName}
-```
-
-Example:
-
-```http
-POST /api/integration/run/coupa-supplier-inbound
-```
-
-## Config model
-A sample full integration config is provided at:
-
-- `config/integrations/coupa-supplier-inbound.json`
-
-It defines:
-- `integrationName`
-- `direction`
-- `source`
-- `target`
-- `processingMode`
-- `batchSize`
-- `degreeOfParallelism`
-- `mapping.tables[]`
-
-## Observability
-- Correlation ID middleware (`X-Correlation-ID`)
-- Global exception middleware
-- Application Insights telemetry
-- Health checks (`/health`, `/health/live`, `/health/ready`)
-- Structured logging via ASP.NET + `ILogger`
-
-## Dependency injection
-Engine registration is centralized in:
-
-- `AddIntegrationEngine(...)`
-
-This wires configuration provider, mapping engine, all provider strategies, factories, and error logging service.
-
-## Notes on scalability
-- Stateless orchestration (no shared mutable in-memory request state)
-- Async IO paths end-to-end
-- Polly retries on outbound HTTP providers
-- Batch + parallel bulk execution
-- Factory-driven extensibility for adding new sources/targets without changing orchestration logic
-
-
-## Endpoint URL configuration
-API endpoint paths for Coupa/MS Dynamics are resolved from `appsettings.json` (`IntegrationEngine:ApiEndpoints`) using symbolic values in integration config (e.g., `"endpoint": "@CoupaSuppliersGet"`).

--- a/src/Coupa.Supplier.Api/Controllers/IntegrationController.cs
+++ b/src/Coupa.Supplier.Api/Controllers/IntegrationController.cs
@@ -10,15 +10,15 @@ public sealed class IntegrationController(IIntegrationOrchestrator orchestrator)
 {
     [HttpPost("run/{integrationName}")]
     [ProducesResponseType(typeof(IntegrationRunResult), StatusCodes.Status200OK)]
-    public async Task<IActionResult> Run([FromRoute] string integrationName, CancellationToken cancellationToken)
-    {
-        var result = await orchestrator.RunAsync(integrationName, cancellationToken);
-        return Ok(result);
-    }
+    public Task<IActionResult> Run([FromRoute] string integrationName, CancellationToken cancellationToken)
+        => RunIntegrationAsync(integrationName, cancellationToken);
 
     [HttpPost("outbound/{integrationName}")]
     [ProducesResponseType(typeof(IntegrationRunResult), StatusCodes.Status200OK)]
-    public async Task<IActionResult> RunOutbound([FromRoute] string integrationName, CancellationToken cancellationToken)
+    public Task<IActionResult> RunOutbound([FromRoute] string integrationName, CancellationToken cancellationToken)
+        => RunIntegrationAsync(integrationName, cancellationToken);
+
+    private async Task<IActionResult> RunIntegrationAsync(string integrationName, CancellationToken cancellationToken)
     {
         var result = await orchestrator.RunAsync(integrationName, cancellationToken);
         return Ok(result);

--- a/src/Coupa.Supplier.Infrastructure/Security/TokenProvider.cs
+++ b/src/Coupa.Supplier.Infrastructure/Security/TokenProvider.cs
@@ -1,14 +1,13 @@
 using Coupa.Supplier.Application.Configuration;
-using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Options;
 
 namespace Coupa.Supplier.Infrastructure.Security;
 
-public sealed class TokenProvider(IConfiguration configuration, IOptions<CoupaOptions> coupaOptions) : ITokenProvider
+public sealed class TokenProvider(IOptions<CoupaOptions> coupaOptions) : ITokenProvider
 {
     public Task<string> GetTokenAsync(CancellationToken cancellationToken)
     {
-        var token = coupaOptions.Value.BearerToken ?? configuration["Coupa:BearerToken"];
+        var token = coupaOptions.Value.BearerToken;
         if (string.IsNullOrWhiteSpace(token))
         {
             throw new InvalidOperationException("Coupa bearer token is not configured.");

--- a/tests/Coupa.Supplier.Infrastructure.Tests/Coupa.Supplier.Infrastructure.Tests.csproj
+++ b/tests/Coupa.Supplier.Infrastructure.Tests/Coupa.Supplier.Infrastructure.Tests.csproj
@@ -6,6 +6,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\Coupa.Supplier.Infrastructure\Coupa.Supplier.Infrastructure.csproj" />
     <ProjectReference Include="..\..\src\Coupa.Supplier.Application\Coupa.Supplier.Application.csproj" />
+    <ProjectReference Include="..\..\src\Coupa.Supplier.Api\Coupa.Supplier.Api.csproj" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="*" />
@@ -20,6 +21,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Options" Version="*" />
+    <PackageReference Include="Moq" Version="*" />
   </ItemGroup>
   <ItemGroup>
     <None Include="config\**\*">

--- a/tests/Coupa.Supplier.Infrastructure.Tests/Flow/IntegrationControllerEndToEndFlowTests.cs
+++ b/tests/Coupa.Supplier.Infrastructure.Tests/Flow/IntegrationControllerEndToEndFlowTests.cs
@@ -1,0 +1,195 @@
+using System.Text.Json.Nodes;
+using Coupa.Supplier.Api.Controllers;
+using Coupa.Supplier.Application.IntegrationEngine;
+using Coupa.Supplier.Domain.IntegrationEngine.Abstractions;
+using Coupa.Supplier.Domain.IntegrationEngine.Models;
+using Coupa.Supplier.Infrastructure.IntegrationEngine.Factories;
+using Coupa.Supplier.Infrastructure.IntegrationEngine.Mapping;
+using Coupa.Supplier.Infrastructure.IntegrationEngine.Persistence;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Coupa.Supplier.Infrastructure.Tests.Flow;
+
+public sealed class IntegrationControllerEndToEndFlowTests
+{
+    [Fact]
+    public async Task Run_Should_Map_Sample_Json_And_Use_Dynamic_Bulk_Target_Without_Db_Call()
+    {
+        var sourcePayload = JsonNode.Parse("""
+        {
+          "id": 8,
+          "name": "Bright Technologies Inc.",
+          "status": "active",
+          "supplier-sites": [
+            { "id": 1, "code": "SF_CODE", "name": "San Francisco", "po-method": "prompt", "po-change-method": "prompt", "active": true }
+          ]
+        }
+        """)!;
+
+        var configProvider = new Mock<IIntegrationConfigProvider>();
+        configProvider
+            .Setup(x => x.GetByNameAsync("coupa-supplier-inbound", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new IntegrationConfiguration
+            {
+                IntegrationName = "coupa-supplier-inbound",
+                ProcessingMode = "Bulk",
+                BatchSize = 100,
+                DegreeOfParallelism = 1,
+                Source = new SourceConfiguration { Type = "Coupa" },
+                Target = new TargetConfiguration { Type = "OracleIndia" },
+                Mapping = BuildSupplierMapping()
+            });
+
+        var coupaSource = new StubSourceProvider("Coupa", [sourcePayload]);
+        var sqlSource = new StubSourceProvider("Sql", []);
+        var oracleTarget = new CapturingTargetProvider("OracleIndia");
+        var sqlTarget = new CapturingTargetProvider("SqlServer");
+
+        var orchestrator = new IntegrationOrchestrator(
+            configProvider.Object,
+            new SourceProviderFactory([coupaSource, sqlSource]),
+            new TargetProviderFactory([oracleTarget, sqlTarget]),
+            new MetadataMappingEngine(new InMemorySequenceGenerator()),
+            Mock.Of<IErrorLogService>(),
+            Mock.Of<ILogger<IntegrationOrchestrator>>());
+
+        var controller = new IntegrationController(orchestrator);
+
+        var result = await controller.Run("coupa-supplier-inbound", CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var payload = ok.Value.Should().BeOfType<IntegrationRunResult>().Subject;
+        payload.TotalReceived.Should().Be(1);
+        payload.TotalSucceeded.Should().Be(1);
+        payload.TotalFailed.Should().Be(0);
+
+        oracleTarget.BulkInsertCalls.Should().Be(1);
+        oracleTarget.SingleInsertCalls.Should().Be(0);
+        sqlTarget.BulkInsertCalls.Should().Be(0);
+        sqlTarget.SingleInsertCalls.Should().Be(0);
+
+        oracleTarget.LastMappedData.Should().NotBeNull();
+        var mapped = oracleTarget.LastMappedData!;
+        mapped["xxfin.xxfin_coupa_suppliers"].ColumnData["NAME"][0].Should().Be("BRIGHT TECHNOLOGIES INC.");
+        mapped["xxfin.xxfin_coupa_suppliers"].ColumnData["SUPPLIER_ID"][0].Should().Be(8L);
+        mapped["xxfin.xxfin_coupa_supp_sites"].ColumnData["SITE_ID"][0].Should().Be(1L);
+        mapped["xxfin.xxfin_coupa_supp_sites"].ColumnData["STG_ID"][0].Should().Be(1L);
+    }
+
+    [Fact]
+    public async Task RunOutbound_Should_Map_Sample_Json_And_Use_Dynamic_Single_Target_Without_Db_Call()
+    {
+        var sourcePayload = JsonNode.Parse("""{ "id": 42, "name": "Contoso" }""")!;
+
+        var configProvider = new Mock<IIntegrationConfigProvider>();
+        configProvider
+            .Setup(x => x.GetByNameAsync("coupa-supplier-outbound", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new IntegrationConfiguration
+            {
+                IntegrationName = "coupa-supplier-outbound",
+                ProcessingMode = "Single",
+                BatchSize = 100,
+                DegreeOfParallelism = 1,
+                Source = new SourceConfiguration { Type = "Coupa" },
+                Target = new TargetConfiguration { Type = "SqlServer" },
+                Mapping = BuildSupplierMapping()
+            });
+
+        var coupaSource = new StubSourceProvider("Coupa", [sourcePayload]);
+        var oracleTarget = new CapturingTargetProvider("OracleIndia");
+        var sqlTarget = new CapturingTargetProvider("SqlServer");
+
+        var orchestrator = new IntegrationOrchestrator(
+            configProvider.Object,
+            new SourceProviderFactory([coupaSource]),
+            new TargetProviderFactory([oracleTarget, sqlTarget]),
+            new MetadataMappingEngine(new InMemorySequenceGenerator()),
+            Mock.Of<IErrorLogService>(),
+            Mock.Of<ILogger<IntegrationOrchestrator>>());
+
+        var controller = new IntegrationController(orchestrator);
+
+        var result = await controller.RunOutbound("coupa-supplier-outbound", CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        var payload = ok.Value.Should().BeOfType<IntegrationRunResult>().Subject;
+        payload.TotalReceived.Should().Be(1);
+        payload.TotalSucceeded.Should().Be(1);
+        payload.TotalFailed.Should().Be(0);
+
+        sqlTarget.SingleInsertCalls.Should().Be(1);
+        sqlTarget.BulkInsertCalls.Should().Be(0);
+        oracleTarget.SingleInsertCalls.Should().Be(0);
+        oracleTarget.BulkInsertCalls.Should().Be(0);
+    }
+
+    private static MappingConfiguration BuildSupplierMapping()
+        => new()
+        {
+            Tables =
+            [
+                new TableMappingConfiguration
+                {
+                    TableName = "xxfin.xxfin_coupa_suppliers",
+                    Alias = "SUPPLIERS",
+                    CollectionPath = "$",
+                    PrimaryKey = "STG_ID",
+                    GeneratePrimaryKey = "sequence(XXFIN_SUPP_STG_SEQ)",
+                    Fields =
+                    [
+                        new FieldMappingConfiguration { SourcePath = "$.id", TargetColumn = "SUPPLIER_ID", IsRequired = true, DataType = "number" },
+                        new FieldMappingConfiguration { SourcePath = "upper($.name)", TargetColumn = "NAME", IsRequired = true, DataType = "string" }
+                    ]
+                },
+                new TableMappingConfiguration
+                {
+                    TableName = "xxfin.xxfin_coupa_supp_sites",
+                    Alias = "SUPPLIER_SITES",
+                    CollectionPath = "$.supplier-sites[*]",
+                    ParentAlias = "SUPPLIERS",
+                    ParentKeyColumn = "STG_ID",
+                    Fields =
+                    [
+                        new FieldMappingConfiguration { SourcePath = "$.id", TargetColumn = "SITE_ID", IsRequired = true, DataType = "number" }
+                    ]
+                }
+            ]
+        };
+
+    private sealed class StubSourceProvider(string sourceType, JsonArray payload) : ISourceProvider
+    {
+        public string SourceType { get; } = sourceType;
+
+        public Task<JsonArray> GetDataAsync(SourceConfiguration sourceConfig, CancellationToken cancellationToken)
+            => Task.FromResult(payload);
+
+        public Task SendDataAsync(SourceConfiguration sourceConfig, JsonObject payload, CancellationToken cancellationToken)
+            => Task.CompletedTask;
+    }
+
+    private sealed class CapturingTargetProvider(string targetType) : ITargetProvider
+    {
+        public string TargetType { get; } = targetType;
+        public int SingleInsertCalls { get; private set; }
+        public int BulkInsertCalls { get; private set; }
+        public Dictionary<string, TableBatchData>? LastMappedData { get; private set; }
+
+        public Task InsertSingleAsync(TargetConfiguration targetConfig, Dictionary<string, TableBatchData> mappedData, CancellationToken cancellationToken)
+        {
+            SingleInsertCalls++;
+            LastMappedData = mappedData;
+            return Task.CompletedTask;
+        }
+
+        public Task InsertBulkAsync(TargetConfiguration targetConfig, Dictionary<string, TableBatchData> mappedData, CancellationToken cancellationToken)
+        {
+            BulkInsertCalls++;
+            LastMappedData = mappedData;
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/tests/Coupa.Supplier.Infrastructure.Tests/Flow/IntegrationControllerFlowTests.cs
+++ b/tests/Coupa.Supplier.Infrastructure.Tests/Flow/IntegrationControllerFlowTests.cs
@@ -1,0 +1,48 @@
+using Coupa.Supplier.Api.Controllers;
+using Coupa.Supplier.Domain.IntegrationEngine.Abstractions;
+using Coupa.Supplier.Domain.IntegrationEngine.Models;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using Xunit;
+
+namespace Coupa.Supplier.Infrastructure.Tests.Flow;
+
+public sealed class IntegrationControllerFlowTests
+{
+    [Fact]
+    public async Task Run_Should_Return_Ok_And_Call_Orchestrator_Without_Db_Call()
+    {
+        var orchestrator = new Mock<IIntegrationOrchestrator>();
+        var expected = new IntegrationRunResult("coupa-supplier-inbound", 10, 8, 2, []);
+        orchestrator
+            .Setup(x => x.RunAsync("coupa-supplier-inbound", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        var controller = new IntegrationController(orchestrator.Object);
+
+        var result = await controller.Run("coupa-supplier-inbound", CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ok.Value.Should().BeEquivalentTo(expected);
+        orchestrator.Verify(x => x.RunAsync("coupa-supplier-inbound", It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RunOutbound_Should_Return_Ok_And_Call_Orchestrator_Without_Db_Call()
+    {
+        var orchestrator = new Mock<IIntegrationOrchestrator>();
+        var expected = new IntegrationRunResult("coupa-supplier-outbound", 6, 6, 0, []);
+        orchestrator
+            .Setup(x => x.RunAsync("coupa-supplier-outbound", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expected);
+
+        var controller = new IntegrationController(orchestrator.Object);
+
+        var result = await controller.RunOutbound("coupa-supplier-outbound", CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ok.Value.Should().BeEquivalentTo(expected);
+        orchestrator.Verify(x => x.RunAsync("coupa-supplier-outbound", It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/tests/Coupa.Supplier.Infrastructure.Tests/Flow/SuppliersControllerFlowTests.cs
+++ b/tests/Coupa.Supplier.Infrastructure.Tests/Flow/SuppliersControllerFlowTests.cs
@@ -1,0 +1,93 @@
+using Coupa.Supplier.Api.Controllers;
+using Coupa.Supplier.Application.Abstractions;
+using Coupa.Supplier.Application.Configuration;
+using Coupa.Supplier.Application.DTOs;
+using Coupa.Supplier.Application.Interfaces;
+using Coupa.Supplier.Application.Services;
+using Coupa.Supplier.Domain.Entities;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Coupa.Supplier.Infrastructure.Tests.Flow;
+
+public sealed class SuppliersControllerFlowTests
+{
+    [Fact]
+    public async Task Sync_Should_Return_Ok_And_Insert_Valid_Suppliers_Without_Db_Call()
+    {
+        var coupaClient = new Mock<ICoupaSupplierClient>();
+        coupaClient
+            .Setup(x => x.GetSuppliersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new SupplierAggregate { SupplierId = 10, Name = "Acme", RawJson = "{\"id\":10}" }
+            ]);
+
+        var repository = new Mock<ITargetSupplierRepository>();
+        repository.SetupGet(x => x.TargetName).Returns("oracle");
+        repository
+            .Setup(x => x.InsertBatchAsync(It.IsAny<IReadOnlyCollection<SupplierAggregate>>(), true, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((IReadOnlyCollection<SupplierAggregate> rows, bool _, CancellationToken _) => rows.Count);
+
+        var strategy = new Mock<ITargetRepositoryStrategy>();
+        strategy.Setup(x => x.Resolve(It.IsAny<string?>())).Returns(repository.Object);
+
+        var service = CreateSupplierSyncService(coupaClient.Object, strategy.Object);
+        var controller = new SuppliersController(service, new SupplierSyncRequestValidator());
+
+        var result = await controller.Sync(new SyncSuppliersRequest(Target: "oracle", UseBulkInsert: true, BatchSize: 100, DegreeOfParallelism: 1), CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ok.Value.Should().BeEquivalentTo(new SyncSuppliersResult(1, 1, 0));
+        repository.Verify(x => x.InsertBatchAsync(It.IsAny<IReadOnlyCollection<SupplierAggregate>>(), true, It.IsAny<CancellationToken>()), Times.Once);
+        repository.Verify(x => x.LogErrorAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Sync_Should_Log_Invalid_Suppliers_Without_Db_Call()
+    {
+        var coupaClient = new Mock<ICoupaSupplierClient>();
+        coupaClient
+            .Setup(x => x.GetSuppliersAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync([
+                new SupplierAggregate { SupplierId = 0, Name = "", RawJson = "{\"id\":0}", Source = "COUPA" }
+            ]);
+
+        var repository = new Mock<ITargetSupplierRepository>();
+        repository.SetupGet(x => x.TargetName).Returns("oracle");
+        repository.Setup(x => x.InsertBatchAsync(It.IsAny<IReadOnlyCollection<SupplierAggregate>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>())).ReturnsAsync(0);
+
+        var strategy = new Mock<ITargetRepositoryStrategy>();
+        strategy.Setup(x => x.Resolve(It.IsAny<string?>())).Returns(repository.Object);
+
+        var service = CreateSupplierSyncService(coupaClient.Object, strategy.Object);
+        var controller = new SuppliersController(service, new SupplierSyncRequestValidator());
+
+        var result = await controller.Sync(new SyncSuppliersRequest(Target: "oracle", UseBulkInsert: true, BatchSize: 10, DegreeOfParallelism: 1), CancellationToken.None);
+
+        var ok = result.Should().BeOfType<OkObjectResult>().Subject;
+        ok.Value.Should().BeEquivalentTo(new SyncSuppliersResult(1, 0, 1));
+        repository.Verify(x => x.InsertBatchAsync(It.IsAny<IReadOnlyCollection<SupplierAggregate>>(), It.IsAny<bool>(), It.IsAny<CancellationToken>()), Times.Never);
+        repository.Verify(x => x.LogErrorAsync("COUPA", "{\"id\":0}", It.Is<string>(m => m.Contains("Required fields missing")), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    private static SupplierSyncService CreateSupplierSyncService(ICoupaSupplierClient coupaClient, ITargetRepositoryStrategy strategy)
+    {
+        var scopeFactory = new Mock<IServiceScopeFactory>();
+        var scope = new Mock<IServiceScope>();
+        var provider = new Mock<IServiceProvider>();
+        provider.Setup(x => x.GetService(typeof(ITargetRepositoryStrategy))).Returns(strategy);
+        scope.SetupGet(x => x.ServiceProvider).Returns(provider.Object);
+        scopeFactory.Setup(x => x.CreateScope()).Returns(scope.Object);
+
+        return new SupplierSyncService(
+            coupaClient,
+            scopeFactory.Object,
+            Mock.Of<ILogger<SupplierSyncService>>(),
+            Options.Create(new SyncOptions { BatchSize = 50, DegreeOfParallelism = 1, UseBulkInsertDefault = false }));
+    }
+}


### PR DESCRIPTION
### Motivation
- Add end-to-end style tests that exercise IntegrationController -> IntegrationOrchestrator -> Mapping -> TargetProvider flow using sample JSON without touching a real DB. 
- Verify mapping behavior (expressions, coercion, parent-child key propagation) and dynamic target selection via the provider factories. 
- Reduce duplication in the controller endpoints and make the Coupa token retrieval more explicit by using options. 
- Update README and test project references to reflect new test coverage and API project involvement.

### Description
- Added new flow tests under `tests/Coupa.Supplier.Infrastructure.Tests/Flow/`: `IntegrationControllerEndToEndFlowTests.cs`, `IntegrationControllerFlowTests.cs`, and `SuppliersControllerFlowTests.cs` that include stub source providers and capturing target providers to validate mapping and dynamic target resolution. 
- Refactored `IntegrationController` to consolidate endpoint logic into a single private `RunIntegrationAsync` method and make `Run`/`RunOutbound` delegate to it. 
- Simplified `TokenProvider` to remove direct `IConfiguration` dependency and use `IOptions<CoupaOptions>` only, and throw if no bearer token is configured. 
- Updated `tests/Coupa.Supplier.Infrastructure.Tests.csproj` to reference the API project and added `Moq` to test dependencies, and shortened/rewrote `README.md` to reflect the current project layout and run instructions.

### Testing
- Added and committed the new tests; an attempt was made to run the suite with `dotnet test Coupa.Supplier.sln`, but the environment lacks the `dotnet` runtime and the command failed with `bash: command not found: dotnet`. 
- All changes were validated locally in the repository (files compile-time style) and committed, but automated test execution could not be completed in this environment due to the missing `dotnet` tool.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dcb6fcde48324bc60a68389c01db3)